### PR TITLE
add javascript controller naming to twig

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,26 @@ is rendered to
 <div data-controller="hello" data-hello-my-value-value="Hey!" data-hello-my-number-value="1234"></<div>
 ```
 
+You can use two ways to specify the controller:
+
+*Assuming the controller is located at `assets/controllers/user/user_form_controller.js`*
+
+- the "HTML" stimulus type
+
+  ```twig
+  <div {{ hello_stimulus_controller('user--user-form') }}></div>
+  // rendered to data-controller="user--user-form"
+  ```
+
+- the "JavaScript" type
+
+  ```php
+  <div {{ hello_stimulus_controller('user/user_form') }}></div>
+  // rendered to data-controller="user--user-form"
+  ```
+
+Both variants give the same result.
+
 
 
 ### hello_stimulus_target(controllerName, target)
@@ -174,7 +194,7 @@ You can use two ways to specify the controller:
 
 *Assuming the controller is located at `assets/controllers/user/user_form_controller.js`*
 
-- the" HTML" stimulus type
+- the "HTML" stimulus type
 
   ```php
   $this->formController = new StimulusFormHelper('user--user-form');

--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ You can use two ways to specify the controller:
 
   ```twig
   <div {{ hello_stimulus_controller('user--user-form') }}></div>
-  // rendered to data-controller="user--user-form"
+  {# rendered to data-controller="user--user-form" #}
   ```
 
 - the "JavaScript" type
 
-  ```php
+  ```twig
   <div {{ hello_stimulus_controller('user/user_form') }}></div>
-  // rendered to data-controller="user--user-form"
+  {# rendered to data-controller="user--user-form" #}
   ```
 
 Both variants give the same result.

--- a/src/Form/StimulusFormHelper.php
+++ b/src/Form/StimulusFormHelper.php
@@ -3,6 +3,7 @@
 
 namespace HelloSebastian\HelloStimulusBundle\Form;
 
+use HelloSebastian\HelloStimulusBundle\Util\ControllerNameTrait;
 use Symfony\Component\Form\FormView;
 
 /**
@@ -10,6 +11,8 @@ use Symfony\Component\Form\FormView;
  */
 class StimulusFormHelper
 {
+    use ControllerNameTrait;
+
     /**
      * @var string
      */
@@ -28,9 +31,7 @@ class StimulusFormHelper
      */
     public function __construct($controllerName, $defaultEvent = "click")
     {
-        $tempName = str_replace("_", "-", $controllerName);
-        $this->controllerName = str_replace("/", "--", $tempName);
-
+        $this->controllerName = $this->transformControllerName($controllerName);
         $this->defaultEvent = $defaultEvent;
     }
 

--- a/src/Twig/HelloStimulusTwigExtension.php
+++ b/src/Twig/HelloStimulusTwigExtension.php
@@ -50,10 +50,13 @@ class HelloStimulusTwigExtension extends AbstractExtension
 
     public function renderController(Environment $twig, $controllerName, $values = array())
     {
+        $controllerName = str_replace("_", "-", $controllerName);
+        $controllerName = str_replace("/", "--", $controllerName);
+
         $dataset = 'data-controller="' . $controllerName . '"';
 
         foreach ($values as $value) {
-            $dataset .= " " . $this->renderValue($twig, $controllerName, $value['name'], $value['value']);
+            $dataset .= ' ' . $this->renderValue($twig, $controllerName, $value['name'], $value['value']);
         }
 
         return $dataset;

--- a/src/Twig/HelloStimulusTwigExtension.php
+++ b/src/Twig/HelloStimulusTwigExtension.php
@@ -4,12 +4,14 @@
 namespace HelloSebastian\HelloStimulusBundle\Twig;
 
 
+use HelloSebastian\HelloStimulusBundle\Util\ControllerNameTrait;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 class HelloStimulusTwigExtension extends AbstractExtension
 {
+    use ControllerNameTrait;
 
     /**
      * {@inheritdoc}
@@ -50,10 +52,7 @@ class HelloStimulusTwigExtension extends AbstractExtension
 
     public function renderController(Environment $twig, $controllerName, $values = array())
     {
-        $controllerName = str_replace("_", "-", $controllerName);
-        $controllerName = str_replace("/", "--", $controllerName);
-
-        $dataset = 'data-controller="' . $controllerName . '"';
+        $dataset = 'data-controller="' . $this->transformControllerName($controllerName) . '"';
 
         foreach ($values as $value) {
             $dataset .= ' ' . $this->renderValue($twig, $controllerName, $value['name'], $value['value']);
@@ -64,18 +63,18 @@ class HelloStimulusTwigExtension extends AbstractExtension
 
     public function renderTarget(Environment $twig, $controllerName, $target)
     {
-        return 'data-' . $controllerName . '-target="' . $target . '"';
+        return 'data-' . $this->transformControllerName($controllerName) . '-target="' . $target . '"';
     }
 
     public function renderAction(Environment $twig, $controllerName, $event, $method)
     {
-        return 'data-action="' . $event . '->' . $controllerName . '#' . $method . '"';
+        return 'data-action="' . $event . '->' . $this->transformControllerName($controllerName) . '#' . $method . '"';
     }
 
     public function renderValue(Environment $twig, $controllerName, $name, $value)
     {
         $kebabCaseName = strtolower(preg_replace('%([A-Z])([a-z])%', '-\1\2', $name));
-        return 'data-' . $controllerName . '-' . $kebabCaseName . '-value="' . $value . '"';
+        return 'data-' . $this->transformControllerName($controllerName) . '-' . $kebabCaseName . '-value="' . $value . '"';
     }
 
 

--- a/src/Util/ControllerNameTrait.php
+++ b/src/Util/ControllerNameTrait.php
@@ -10,7 +10,7 @@ trait ControllerNameTrait
      * Transform controller name from "JavaScript" to "HTML" way to specify controller.
      *
      * @param string $controllerName
-     * @return string|string[]
+     * @return string
      */
     private function transformControllerName($controllerName)
     {

--- a/src/Util/ControllerNameTrait.php
+++ b/src/Util/ControllerNameTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace HelloSebastian\HelloStimulusBundle\Util;
+
+
+trait ControllerNameTrait
+{
+    /**
+     * Transform controller name from "JavaScript" to "HTML" way to specify controller.
+     *
+     * @param string $controllerName
+     * @return string|string[]
+     */
+    private function transformControllerName($controllerName)
+    {
+        $tempName = str_replace("_", "-", $controllerName);
+        return str_replace("/", "--", $tempName);
+    }
+}


### PR DESCRIPTION
Add "JavaScript" way to specify the controller name to twig (already exist in `StimulusFormHelper`).

Example:

*Assuming the controller is located at `assets/controllers/user/user_form_controller.js`*

- the "HTML" stimulus type <-- was already possible now

  ```twig
  <div {{ hello_stimulus_controller('user--user-form') }}></div>
  // rendered to data-controller="user--user-form"
  ```

- the "JavaScript" type <-- new way

  ```php
  <div {{ hello_stimulus_controller('user/user_form') }}></div>
  // rendered to data-controller="user--user-form"
  ```

